### PR TITLE
Updated to CircuitBreaker 5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/alert-notification-sdk.git",
         "state": {
           "branch": null,
-          "revision": "52eb401ec576a7c58838e408f6d423d6c5de997a",
-          "version": "2.0.0"
+          "revision": "3c25a71a9b7b90f45c232e6ed9da46e2b3f233e5",
+          "version": "2.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/CircuitBreaker.git",
         "state": {
           "branch": null,
-          "revision": "252f7bccb70dc34283f7a05ece624075967d1bb2",
-          "version": "3.0.0"
+          "revision": "81581e3fb094ab4879aa2c5ce54201f1dbce0a7f",
+          "version": "5.0.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/CloudEnvironment.git",
         "state": {
           "branch": null,
-          "revision": "446c74f26a6c757b8f694fb66af662396e520eea",
-          "version": "6.0.0"
+          "revision": "d6eda5c4b8b541a8f2e1baeeb3e4722fdaf3dc2d",
+          "version": "6.0.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Swift-cfenv.git",
         "state": {
           "branch": null,
-          "revision": "2b4a8a35ac285f7ad8a09519cbdbe486da5d675b",
-          "version": "6.0.0"
+          "revision": "1cd6067d1f711674d2f277814ef920f3b23ce4cb",
+          "version": "6.0.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Configuration.git",
         "state": {
           "branch": null,
-          "revision": "5a295cffa7083ab6f30cc75de373b729f61a3e7c",
-          "version": "3.0.0"
+          "revision": "a5e3ce4619089069697bbef5abfe3687f6830b9d",
+          "version": "3.0.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
         "state": {
           "branch": null,
-          "revision": "16f9c7ddcbe11bbd32106a791ebef2108a4e9183",
-          "version": "0.8.21"
+          "revision": "12f9be466d1166b16da8cb2a9d549098990248d1",
+          "version": "0.8.25"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
         "state": {
           "branch": null,
-          "revision": "cc8b17a96b61707145ec44094dba434b017e2091",
-          "version": "2.1.2"
+          "revision": "9673af0daf3d3947675acc9c9d0755476ce4aa5b",
+          "version": "2.1.3"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-WebSocket.git",
         "state": {
           "branch": null,
-          "revision": "abfaf1a291e46da0dc0ee90aa3b06e851870adcc",
-          "version": "1.0.0"
+          "revision": "8474fc22b5901409d859b4fb19315734c750877c",
+          "version": "1.0.1"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
         "state": {
           "branch": null,
-          "revision": "fc6e2178bba46b3209709c2e331b3ad4c402e780",
-          "version": "2.0.0"
+          "revision": "d781655dcee403504e4f1eeaf3f62b12d78d8230",
+          "version": "2.0.1"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/KituraContracts.git",
         "state": {
           "branch": null,
-          "revision": "385c5698b5c6ffb3416f810dd71c317be40076cc",
-          "version": "0.0.15"
+          "revision": "4195ce3e6748420ff5c659d5ebba7b5dd4434df0",
+          "version": "0.0.18"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
         "state": {
           "branch": null,
-          "revision": "d657234966e61ec3d9e9c2edec2be0c03cae6e99",
-          "version": "0.12.68"
+          "revision": "fde8b10d1dc727da90a8ae39611498211a64b890",
+          "version": "0.12.77"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
         "state": {
           "branch": null,
-          "revision": "ebd0fd8372c73fd467a447f80f2763d34f3dbe9c",
-          "version": "0.12.79"
+          "revision": "0d2663bf81ae2588b61b358fe4a25d6f0dc4d8af",
+          "version": "0.12.87"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/RuntimeTools/SwiftMetrics.git",
         "state": {
           "branch": null,
-          "revision": "949a9b00c6de7082f95be2af50a21f930cd5c5c7",
-          "version": "2.1.0"
+          "revision": "06a8947400f1822a68f56ddf696ceb3a995a3531",
+          "version": "2.2.0"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/SwiftyRequest.git",
         "state": {
           "branch": null,
-          "revision": "4c571be415d71f1f45d5c44ccc92b17a47acde88",
-          "version": "1.0.0"
+          "revision": "0b1b181278014248ea34d8568f34580b64f85441",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/CircuitBreaker.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/CircuitBreaker.git", from: "5.0.0"),
         .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/alert-notification-sdk.git", from: "2.0.0")
     ],

--- a/Sources/DemoAppServer/Circuit.swift
+++ b/Sources/DemoAppServer/Circuit.swift
@@ -74,7 +74,6 @@ func broadcastCircuitStatus(breaker: CircuitBreaker<(URL, RouterResponse, () -> 
             connection.send(message: "half-open")
         case .closed:
             connection.send(message: "closed")
-        default: break
         }
     }
 }

--- a/Sources/DemoAppServer/Controller.swift
+++ b/Sources/DemoAppServer/Controller.swift
@@ -58,7 +58,7 @@ public class Controller {
     var jsonDispatchQueue: DispatchQueue
 
     // Circuit breaker.
-    let breaker: CircuitBreaker<(URL, RouterResponse, () -> Void), Void, (RouterResponse, () -> Void)>
+    let breaker: CircuitBreaker<(URL, RouterResponse, () -> Void), (RouterResponse, () -> Void)>
     var wsConnections: [String: WebSocketConnection]  = [:]
     var broadcastQueue: DispatchQueue
     var circuitEndpointEnabled: Bool
@@ -89,7 +89,7 @@ public class Controller {
         self.jsonDispatchQueue = DispatchQueue(label: "jsonResponseQueue")
 
         // Circuit breaker.
-        self.breaker = CircuitBreaker(timeout: 10000, maxFailures: 3, rollingWindow: 60000, contextCommand: circuitRequestWrapper, fallback: circuitTimeoutCallback)
+        self.breaker = CircuitBreaker(name: "breaker",timeout: 10000, maxFailures: 3, rollingWindow: 60000, command: circuitRequestWrapper, fallback: circuitTimeoutCallback)
         self.broadcastQueue = DispatchQueue(label: "circuitBroadcastQueue", qos: DispatchQoS.userInitiated)
         self.circuitEndpointEnabled = true
         self.circuitDelayTime = 0


### PR DESCRIPTION
Updated the code to use the newer version of CircuitBreaker, from 3.0.0 to 5.0.0. 

There aren't any test cases, to test I set up the configuration.json on a master copy and ran it on local host, and then tested the CircuitBreaker tab on the webpage that loaded. I then tested it again using my changes and got the same results, so I believe my changes are good.